### PR TITLE
patch ZF-10715

### DIFF
--- a/library/Zend/Json/Server.php
+++ b/library/Zend/Json/Server.php
@@ -188,10 +188,14 @@ class Zend_Json_Server extends Zend_Server_Abstract
         }
 
         // Handle request
-        $this->_handle();
+        $handleResponse = $this->_handle();
 
         // Get response
-        $response = $this->_getReadyResponse();
+        if ($handleResponse instanceof Zend_Json_Server_Error) {
+            $response = $this->getResponse()->setError($handleResponse);
+        } else {
+            $response = $this->_getReadyResponse();
+        }
 
         // Emit response?
         if ($this->autoEmitResponse()) {
@@ -501,7 +505,11 @@ class Zend_Json_Server extends Zend_Server_Abstract
      */
     protected function _handle()
     {
-        $request = $this->getRequest();
+        try {
+            $request = $this->getRequest();
+        } catch (Zend_Json_Exception $ex) {
+            return $this->fault('Parse Error', -32768);
+        }
 
         if (!$request->isMethodError() && (null === $request->getMethod())) {
             return $this->fault('Invalid Request', -32600);


### PR DESCRIPTION
> ZF-10715: Zend_Json_Server does not handle invalid JSON requests properly
> Issue Type: Bug Created: 2010-11-19T11:51:19.000+0000 Last Updated: 2011-06-28T15:31:20.000+0000 Status: Open Fix version(s): Reporter: Joshua Johnson (jsjohns2) Assignee: Matthew Weier O'Phinney (matthew) Tags: - Zend_Json_Server
> 
> Related issues: Attachments: - ZF-10715.patch
> 
> Description
> According to the JSON-RPC 2.0 spec: "When a remote procedure call fails, the Procedure Return object MUST contain the error member...". Additionally, the spec lists -32700 as the code for JSON parsing errors.
> 
> Zend_Json_Server does not conform to this part of the spec...if invalid JSON is sent to the server, a PHP error is returned rather than a proper JSON error message. This is what you get: Fatal error: Uncaught exception 'Zend_Json_Exception' with message 'Decoding failed: Syntax error' in /usr/share/pear/Zend/Json.php:93 

_https://framework.zend.com/issues/browse/ZF-10715_

<details>

<summary>screenshot</summary>

![image](https://user-images.githubusercontent.com/1712281/43557092-0b95344e-963e-11e8-8aac-967708c6327a.png)

</details>